### PR TITLE
Fix potential crash in AttributeName::tangoHostWithDomain()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.11.1] - 2020-01-22
+
 ### Fixed
 
 - Fix potential crash in AttributeName::tangoHostWithDomain() [#8](https://github.com/tango-controls-hdbpp/libhdbpp-timescale/pull/8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix potential crash in AttributeName::tangoHostWithDomain() [#8](https://github.com/tango-controls-hdbpp/libhdbpp-timescale/pull/8)
+
 ## [0.11.0] - 2020-01-21
 
 ### Added

--- a/src/AttributeName.cpp
+++ b/src/AttributeName.cpp
@@ -94,7 +94,7 @@ const string &AttributeName::tangoHostWithDomain()
             hints.ai_socktype = SOCK_STREAM;
             hints.ai_flags = AI_CANONNAME;
 
-            struct addrinfo *result, *rp;
+            struct addrinfo *result;
             const int status = getaddrinfo(server_name.c_str(), nullptr, &hints, &result);
 
             if (status != 0)
@@ -104,9 +104,21 @@ const string &AttributeName::tangoHostWithDomain()
 
                 return tangoHost();
             }
-
-            for (rp = result; rp != nullptr; rp = rp->ai_next)
-                server_name_with_domain = string(rp->ai_canonname) + tango_host.substr(tango_host.find(':', 0));
+			
+            if (result == nullptr)
+            {
+                spdlog::error("Error: Unable to add domain to tango host {}: getaddrinfo didn't return the canonical name (result == nullptr)", tango_host);
+                return tangoHost();
+            }
+			
+            if (result->ai_canonname == nullptr)
+            {
+                spdlog::error("Error: Unable to add domain to tango host {}: getaddrinfo didn't return the canonical name (result->ai_canonname == nullptr)", tango_host);
+                freeaddrinfo(result);
+                return tangoHost();
+            }
+            
+            server_name_with_domain = string(result->ai_canonname) + tango_host.substr(tango_host.find(':', 0));
 
             freeaddrinfo(result); // all done with this structure
             _tango_host_with_domain_cache = server_name_with_domain;


### PR DESCRIPTION
Fix crash when getaddrinfo is returning several struct addrinfo
(https://github.com/tango-controls-hdbpp/hdbpp-cm/issues/6#issuecomment-557124799)
The second struct addrinfo contains a field ai-canonname which is NULL.
This could cause a crash because some code is attempting to create a string from a null pointer.

getaddrinfo man page (on Debian Buster) says the following:

        If hints.ai_flags includes the AI_CANONNAME flag, then the ai_canon-
        name field of the first of the addrinfo structures in the returned
        list is set to point to the official name of the host.

So there is no need to look at the following addrinfo returned structures.