### PR TITLE
Remove the need for libpqxx submodule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Removed public headers as the only needed one is AbstractDB from libhdbpp.
+- Moved public headers to private as the only needed one is AbstractDB from libhdbpp.
 - Moved some system documentation to hdbpp-timescale-project (the consolidated project).
 - Consolidated remaining build/install instructions into README
 - Modified build system to use fetch libhdbpp and include it when requested. This is an aid to development.
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 
+- libpqxx submodule, either use the system version or fetch it if not found.
 - Removed the embedded version of libhdbpp (the build can now source it at build time)
 
 ## [0.11.2] - 2020-01-23

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
 # Find the libhdbpp headers
-find_package(libhdbpp)
+find_package(libhdbpp 2)
 
 # If not installed then get them
 if(NOT libhdbpp_FOUND)
@@ -105,21 +105,46 @@ add_subdirectory(thirdparty/google/benchmark EXCLUDE_FROM_ALL)
 add_subdirectory(thirdparty/google/googletest/googletest EXCLUDE_FROM_ALL)
 
 # Include the thirdparty projects
-add_subdirectory(thirdparty/libpqxx  EXCLUDE_FROM_ALL)
+#add_subdirectory(thirdparty/libpqxx  EXCLUDE_FROM_ALL)
 add_subdirectory(thirdparty/spdlog  EXCLUDE_FROM_ALL)
 add_subdirectory(thirdparty/Catch2  EXCLUDE_FROM_ALL)
 
-# For ease of use, we set the libpqxx output to our projects build directory,
-# then if we build libpqxx as a shared library its easy to find 
-set_target_properties(pqxx_shared
-    PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+# Find the libpqxx package
+find_package(libpqxx 6.4)
 
-# Currently we link libpqxx into our library as a static object, to ease 
-# deployment, so we make this small change here.
-set_target_properties(pqxx_static
-    PROPERTIES
-    POSITION_INDEPENDENT_CODE 1)
+# If not installed then get them
+if(NOT libpqxx_FOUND)
+    include(FetchContent)
+
+    FetchContent_Declare(
+      libpqxx
+      GIT_REPOSITORY https://github.com/jtv/libpqxx.git
+      GIT_TAG        6.4.5
+    )
+
+    FetchContent_GetProperties(libpqxx)
+    if(NOT libpqxx_POPULATED)
+        FetchContent_Populate(libpqxx)
+        add_subdirectory(${libpqxx_SOURCE_DIR} ${libpqxx_BINARY_DIR}
+            EXCLUDE_FROM_ALL)
+    endif()
+
+    # Do not run the tests on the libpqxx build
+    set(SKIP_BUILD_TEST ON)
+
+    # For ease of use, we set the libpqxx output to our projects build directory,
+    # then if we build libpqxx as a shared library its easy to find 
+    set_target_properties(pqxx_shared
+        PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+
+    # Currently we link libpqxx into our library as a static object, to ease 
+    # deployment, so we make this small change here.
+    set_target_properties(pqxx_static
+        PROPERTIES
+        POSITION_INDEPENDENT_CODE 1)
+
+endif(NOT libpqxx_FOUND)
 
 # Code Analysis -----------------------------------
 if(ENABLE_CLANG)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ The library requires a correctly configured [TimescaleDb](https://www.timescale.
 
 The library has been build against a number of other projects, these have been integrated into the repository as sub modules. This may change at a later date if the build system is improved. Current sub modules are:
 
-* libpqxx - Modern C++ Postgresql library
 * spdlog - Logging system
 * Catch2 - Unit test subsystem
 

--- a/doc/build.md
+++ b/doc/build.md
@@ -6,7 +6,6 @@ To build the shared library please read the following.
 
 The project has two types of dependencies, those required by the toolchain, and those to do the actual build. Other dependencies are integrated directly into the project as submodules. The following thirdparty modules exists:
 
-* libpqxx - Modern C++ Postgresql library (Submodule)
 * spdlog - Logging system (Submodule)
 * Catch2 - Unit test subsystem (Submodule)
 * libhdbpp - Header from the hdb++ library loading chain (Modified version of [original](https://github.com/tango-controls-hdbpp/libhdbpp) project. This will be pushed back to the original repository in time)
@@ -25,7 +24,7 @@ Ensure the development version of the dependencies are installed. These are as f
 * Tango Controls 9 or higher development headers and libraries
 * omniORB release 4 or higher development headers and libraries
 * libzmq3-dev or libzmq5-dev
-* libpq-dev - Postgres C development library
+* libpq-dev or libpqxx - Postgres C development library, to build libpqxx, or directly libpqxx version 6.4
 
 ## Building and Installation
 


### PR DESCRIPTION
Either use the system libpqxx or use cmake fetch instead of the
submodule.

Note that the submodule has not yet been removed.